### PR TITLE
增加脚本搜索超长时间没有翻译完成的文章

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,6 +29,8 @@
 
 + feed_monitor.py :: 监控feed，列出新增的article link
 
++ search_overdue_translating_articles.sh :: 搜索超长时间没有翻译完成的文章. 使用方法为 =search_overdue_translating_articles.sh [timeout]= 其中timeout单位为天,默认为30天
+
 * 配置说明：
 你可以在lctt.cfg中配置:
 

--- a/search_overdue_translating_articles.sh
+++ b/search_overdue_translating_articles.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+source $(dirname "${BASH_SOURCE[0]}")/base.sh
+cd $(get-lctt-path)
+
+timeout=${1:-30}
+timeout=$(($timeout * 24 * 60 * 60))
+now=$(date +"%s")
+overdue=$((${now} - ${timeout}))
+git grep -niE "translat|fanyi|翻译"  sources/*.md |sort -t ":" -g -k 2 |grep ":1:"|cut -d : -f1 |while read article
+do
+    last_modify_time=$(git log --date=unix --pretty=format:"%cd" -n 1 "${article}" )
+    if [[ ${last_modify_time} -lt ${overdue} ]];then
+        echo "${article}"
+    fi
+done


### PR DESCRIPTION
使用方法为 search_overdue_translating_articles.sh [timeout]
timeout单位为天,默认为30天